### PR TITLE
warnings모듈을 사용하여 DependencyWarning 억제

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,12 +3,22 @@ import json
 import os
 from typing import Dict, List
 import logging
+from datetime import datetime
 
 from python_api_extractor.extracter import api_extracter
 from python_ast_visualizer.utils import ast_to_png
 from search_source.container_extracter import layer_extracter
 from trivy_extracter.trivy_module import trivy_func
 from cve_api_mapper.api_mapper import query_grok
+
+# 로깅 설정: 콘솔과 파일(YYYYMMDD_HHMMSS.log)에 로그 출력
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(),  # 콘솔 출력
+    ]
+)
 
 # 분석 결과 저장을 위한 출력 파일 경로 정의
 TRIVY_OUTPUT_PATH = "DB/trivy_analysis_result.json"

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from search_source.container_extracter import layer_extracter
 from trivy_extracter.trivy_module import trivy_func
 from cve_api_mapper.api_mapper import query_grok
 
-# 로깅 설정: 콘솔과 파일(YYYYMMDD_HHMMSS.log)에 로그 출력
+# 로깅 설정: 콘솔과에 로그 출력
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(levelname)s - %(message)s',

--- a/python_api_extractor/extracter/api_extracter.py
+++ b/python_api_extractor/extracter/api_extracter.py
@@ -6,8 +6,14 @@ import tempfile
 import shutil
 import textwrap
 from typing import Dict, List
+import warnings
+import re
 
-# Helper scripts to extract public APIs and detect top-level modules
+# CryptographyDeprecationWarning과 DependencyWarning을 억제하여 로그를 깔끔하게 유지
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+warnings.filterwarnings("ignore", category=Warning, module="urllib3.contrib.socks")
+
+# 공개 API 추출 및 최상위 모듈 탐지를 위한 도우미 스크립트
 EXTRACT_SCRIPT = textwrap.dedent('''
 import pkgutil
 import importlib
@@ -16,11 +22,18 @@ import json
 import argparse
 import sys
 
-parser = argparse.ArgumentParser(description="Recursively extract public APIs from a package")
-parser.add_argument('module', help="Module name to extract APIs from")
+# 명령줄 인자를 파싱하여 모듈 이름을 받음
+parser = argparse.ArgumentParser(description="패키지에서 공개 API를 재귀적으로 추출")
+parser.add_argument('module', help="API를 추출할 모듈 이름")
 args = parser.parse_args()
 modname = args.module
 
+# 모듈 이름이 유효한지 확인 (Python 식별자 규칙 준수, 점으로 시작하지 않음)
+if not modname.replace(".", "").isidentifier() or modname.startswith("."):
+    print(json.dumps({"functions": []}))
+    sys.exit(0)
+
+# 모듈을 임포트 시도
 try:
     mod = importlib.import_module(modname)
 except ImportError:
@@ -28,6 +41,7 @@ except ImportError:
     sys.exit(0)
 
 apis = set()
+# __all__ 속성이 있으면 이를 사용, 없으면 비공개(_로 시작하지 않는) 이름 사용
 exports = getattr(mod, "__all__", None)
 names = exports if exports is not None else [n for n in dir(mod) if not n.startswith("_")]
 for name in names:
@@ -38,9 +52,12 @@ for name in names:
     if callable(obj):
         apis.add(f"{modname}.{name}")
 
-# Walk through submodules if applicable
+# 패키지인 경우 하위 모듈을 탐색
 if hasattr(mod, '__path__'):
     for finder, subname, ispkg in pkgutil.walk_packages(mod.__path__, modname + '.'):
+        # 특수 모듈(__pip-runner__) 및 유효하지 않은 이름 제외
+        if subname.endswith(".__pip-runner__") or not subname.replace(".", "").isidentifier() or subname.startswith("."):
+            continue
         try:
             submod = importlib.import_module(subname)
         except ImportError:
@@ -55,6 +72,7 @@ if hasattr(mod, '__path__'):
             if callable(obj):
                 apis.add(f"{subname}.{name}")
 
+# 추출된 API 목록을 JSON 형식으로 출력
 print(json.dumps({"functions": sorted(apis)}))
 ''')
 
@@ -62,6 +80,7 @@ DETECT_SCRIPT = textwrap.dedent('''
 import json, sys
 from importlib.metadata import distribution
 
+# 지정된 패키지의 배포 정보를 가져옴
 dist = None
 try:
     dist = distribution(sys.argv[1])
@@ -73,14 +92,24 @@ files = dist.files or []
 top = set()
 for f in files:
     parts = f.parts
+    # .dist-info, .egg-info로 끝나지 않는 최상위 디렉토리만 추가
     if parts and not parts[0].endswith(('.dist-info', '.egg-info')):
-        top.add(parts[0])
+        # 유효한 모듈 이름만 추가 (Python 식별자 규칙 준수, 점으로 시작하지 않음)
+        if parts[0].replace(".", "").isidentifier() and not parts[0].startswith("."):
+            top.add(parts[0])
+# 최상위 모듈 목록을 JSON 형식으로 출력
 print(json.dumps({"modules": sorted(top)}))
 ''')
 
 def map_cves_by_package(report_data: dict) -> Dict[str, Dict[str, List[str]]]:
     """
-    Generate a mapping of CVEs per Python package and version from a Trivy JSON report.
+    Trivy JSON 보고서에서 Python 패키지 및 버전별 CVE 매핑을 생성합니다.
+
+    Args:
+        report_data (dict): Trivy JSON 보고서 데이터
+
+    Returns:
+        Dict[str, Dict[str, List[str]]]: 패키지 이름과 버전별 CVE 목록
     """
     mapping: Dict[str, Dict[str, List[str]]] = {}
     for result in report_data.get("Results", []):
@@ -97,8 +126,15 @@ def map_cves_by_package(report_data: dict) -> Dict[str, Dict[str, List[str]]]:
 
 def extract_api_list(pip_name: str, version: str) -> Dict[str, List[str]]:
     """
-    Create a temporary virtual environment, install the specified package version,
-    detect top-level modules, and extract the list of callable APIs.
+    임시 가상 환경을 생성하고, 지정된 패키지 버전을 설치한 뒤,
+    최상위 모듈을 탐지하고 호출 가능한 API 목록을 추출합니다.
+
+    Args:
+        pip_name (str): 설치할 패키지 이름
+        version (str): 패키지 버전
+
+    Returns:
+        Dict[str, List[str]]: 모듈별 API 목록
     """
     spec = f"{pip_name}=={version}"
     workdir = tempfile.mkdtemp(prefix="api_ext_")
@@ -106,22 +142,29 @@ def extract_api_list(pip_name: str, version: str) -> Dict[str, List[str]]:
     detect_py = os.path.join(workdir, "detect.py")
     extract_py = os.path.join(workdir, "extract.py")
     try:
+        # 가상 환경 생성
         subprocess.run([sys.executable, "-m", "venv", venv_dir], check=True)
         python_bin = os.path.join(venv_dir, 'Scripts' if os.name=='nt' else 'bin', 'python')
+        # pip 업그레이드
         subprocess.run([python_bin, '-m', 'pip', 'install', '--upgrade', 'pip'], check=True, stdout=subprocess.DEVNULL)
         try:
+            # 패키지 설치
             subprocess.run([python_bin, '-m', 'pip', 'install', spec], check=True, stdout=subprocess.DEVNULL)
         except subprocess.CalledProcessError:
             return {}
+        # DETECT_SCRIPT 저장
         with open(detect_py, 'w', encoding='utf-8') as f:
             f.write(DETECT_SCRIPT)
+        # 최상위 모듈 탐지
         out = subprocess.check_output([python_bin, detect_py, pip_name], text=True)
         modules = json.loads(out).get('modules', [])
+        # EXTRACT_SCRIPT 저장
         with open(extract_py, 'w', encoding='utf-8') as f:
             f.write(EXTRACT_SCRIPT)
         results: Dict[str, List[str]] = {}
         for mod in modules:
             try:
+                # 모듈별 API 추출
                 out = subprocess.check_output([python_bin, extract_py, mod], text=True)
                 data = json.loads(out)
                 funcs = data.get('functions', [])
@@ -131,22 +174,27 @@ def extract_api_list(pip_name: str, version: str) -> Dict[str, List[str]]:
                 continue
         return results
     finally:
+        # 임시 디렉토리 정리
         shutil.rmtree(workdir, ignore_errors=True)
 
 
 def build_cve_api_mapping(report_data: dict) -> Dict[str, Dict[str, Dict[str, List[str]]]]:
     """
-    Build a combined mapping of CVEs and APIs per package and version from Trivy report.
+    Trivy 보고서에서 패키지 및 버전별 CVE와 API의 통합 매핑을 생성합니다.
+
+    Args:
+        report_data (dict): Trivy JSON 보고서 데이터
 
     Returns:
-        {package: {version: {'cves': [...], 'apis': {...}}, ...}, ...}
+        Dict[str, Dict[str, Dict[str, List[str]]]]: 패키지와 버전별 CVE 및 API 매핑
+            {패키지: {버전: {'cves': [...], 'apis': {...}}, ...}, ...}
     """
     mapping = map_cves_by_package(report_data)
     combined: Dict[str, Dict[str, Dict[str, List[str]]]] = {}
     for pkg, versions in mapping.items():
         combined[pkg] = {}
         for ver, cves in versions.items():
-            print(f"Extracting APIs for {pkg}@{ver}...")
+            print(f"{pkg}@{ver}의 API 추출 중...")
             apis = extract_api_list(pkg.lower(), ver)
             combined[pkg][ver] = {
                 'cves': cves,


### PR DESCRIPTION
- warnings모듈을 사용하여 `python_api_extractor`에서 발생하는 DependencyWarning 로그 억제
- main.py에서 로그를 더 명확하게 나타내도록 `logging.basicConfig` 추가.